### PR TITLE
#29 Call to a member function format() on false in AudioCore.php:543

### DIFF
--- a/src/Models/AudioCore.php
+++ b/src/Models/AudioCore.php
@@ -539,9 +539,16 @@ class AudioCore
             if (strlen($creation_date) === 4) {
                 $core->setYear((int) $creation_date);
             } else {
-                $creation_date = date_create_from_format('Y-m-d\TH:i:s\Z', $creation_date);
-                $core->setCreationDate($creation_date?->format('Y-m-d\TH:i:s\Z'));
-                $core->setYear((int) $creation_date?->format('Y'));
+                try {
+                    $parsedCreationDate = new \DateTimeImmutable($creation_date);
+                } catch (\Exception $e) {
+                    // ignore the issue so the rest of the data will be available
+                }
+
+                if (!empty($parsedCreationDate)) {
+                    $core->setCreationDate($parsedCreationDate->format('Y-m-d\TH:i:s\Z'));
+                    $core->setYear((int) $parsedCreationDate->format('Y'));
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #29 by:

- use `DateTimeImmutable` super powers to parse date and datetime strings
- catch and ignore exception when instantiating the aforementioned object so the whole script won't fail
- remove the null safe operators when it's not needed